### PR TITLE
replaced tdid with whoAmI everywhere

### DIFF
--- a/dist/Marty.d.ts
+++ b/dist/Marty.d.ts
@@ -15,6 +15,7 @@ export declare class Marty {
     _ricFriendlyNameIsSet: boolean;
     _calibInfo: RICCalibInfo | null;
     _hwElems: Array<RICHWElem>;
+    _hwElems2: Array<RICHWElem>;
     _addOnManager: RICAddOnManager;
     _discoveryListener: RICDiscoveryListener | null;
     _progressAfterDownload: number;
@@ -155,7 +156,7 @@ export declare class Marty {
      *
      */
     hwElemFirmwareUpdate(): Promise<RICOKFail>;
-    convertHWElemType(whoAmITypeCode: string | undefined, whoAmI: string | undefined): string;
+    convertHWElemType(whoAmI: string | undefined): string;
     /**
      *
      * getHWElemList - get list of HWElems on the robot (including add-ons)

--- a/dist/Marty.js
+++ b/dist/Marty.js
@@ -50,6 +50,7 @@ export class Marty {
         this._calibInfo = null;
         // HWElems (connected to RIC)
         this._hwElems = new Array();
+        this._hwElems2 = new Array();
         // Add-on Manager
         this._addOnManager = new RICAddOnManager();
         // Listener for state changes
@@ -103,6 +104,7 @@ export class Marty {
         this._ricMsgHandler.registerForResults(this);
         this._ricMsgHandler.registerMsgSender(this._connManager);
         this._ricFileHandler.registerMsgSender(this._connManager);
+        console.log("initialising marty", 'Marty.ts', 'line: ', '158');
     }
     // Callback for RIC events including data
     setEventListener(listener) {
@@ -528,8 +530,8 @@ export class Marty {
         });
     }
     //get the name of the addons type from the type code
-    convertHWElemType(whoAmITypeCode, whoAmI) {
-        return this._addOnManager.convertHWElemType(whoAmITypeCode, whoAmI);
+    convertHWElemType(whoAmI) {
+        return this._addOnManager.convertHWElemType(whoAmI);
     }
     // Mark: Get HWElem list -----------------------------------------------------------
     /**

--- a/dist/RICAddOnManager.d.ts
+++ b/dist/RICAddOnManager.d.ts
@@ -6,7 +6,7 @@ export default class RICAddOnManager {
     _addOnMap: Dictionary<RICAddOnBase>;
     setHWElems(hwElems: Array<RICHWElem>): void;
     clear(): void;
-    convertHWElemType(whoAmITypeCode: string | undefined, whoAmI: string | undefined): string;
+    convertHWElemType(whoAmI: string | undefined): string;
     getMappingOfAddOns(hwElems: Array<RICHWElem>): Dictionary<RICAddOnBase>;
     processPublishedData(addOnID: number, statusByte: number, rawData: Uint8Array): ROSSerialAddOnStatus | null;
 }

--- a/dist/RICAddOnManager.js
+++ b/dist/RICAddOnManager.js
@@ -1,4 +1,4 @@
-import { getHWElemTypeStr, RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO, RICAddOnGripServo, RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT, RICAddOnLEDFoot, RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM, RICAddOnLEDArm, RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE, RICAddOnLEDEye, RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1, RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2, RICAddOnIRFoot, RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR, RICAddOnColourSensor, RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE, RICAddOnDistanceSensor, RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT, RICAddOnLightSensor, RIC_WHOAMI_TYPE_CODE_ADDON_NOISE, RICAddOnNoiseSensor, } from './RICAddOns.js';
+import { getHWElemTypeStr, RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO, RICAddOnGripServo, RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT, RICAddOnLEDFoot, RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM, RICAddOnLEDArm, RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE, RICAddOnLEDEye, RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT, RICAddOnIRFoot, RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR, RICAddOnColourSensor, RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE, RICAddOnDistanceSensor, RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT, RICAddOnLightSensor, RIC_WHOAMI_TYPE_CODE_ADDON_NOISE, RICAddOnNoiseSensor, } from './RICAddOns.js';
 export default class RICAddOnManager {
     constructor() {
         this._addOnMap = {};
@@ -9,42 +9,41 @@ export default class RICAddOnManager {
     clear() {
         this._addOnMap = {};
     }
-    convertHWElemType(whoAmITypeCode, whoAmI) {
-        return getHWElemTypeStr(whoAmITypeCode, whoAmI);
+    convertHWElemType(whoAmI) {
+        return getHWElemTypeStr(whoAmI);
     }
     getMappingOfAddOns(hwElems) {
         const addOnMap = {};
         // Iterate HWElems to find addons
         for (const hwElem of hwElems) {
-            const dtid = parseInt("0x" + hwElem.whoAmITypeCode);
+            console.log(hwElem.whoAmI, 'RICAddOnManager.ts', 'line: ', '50');
             if (hwElem.type === 'RSAddOn') {
-                switch (dtid) {
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO):
+                switch (hwElem.whoAmI) {
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnGripServo(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT):
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnLEDFoot(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM):
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnLEDArm(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE):
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnLEDEye(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1):
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2):
-                        addOnMap[hwElem.IDNo.toString()] = new RICAddOnIRFoot(hwElem.name, dtid);
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT:
+                        addOnMap[hwElem.IDNo.toString()] = new RICAddOnIRFoot(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR):
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnColourSensor(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE):
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnDistanceSensor(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT):
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnLightSensor(hwElem.name);
                         break;
-                    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_NOISE):
+                    case RIC_WHOAMI_TYPE_CODE_ADDON_NOISE:
                         addOnMap[hwElem.IDNo.toString()] = new RICAddOnNoiseSensor(hwElem.name);
                         break;
                 }

--- a/dist/RICAddOns.d.ts
+++ b/dist/RICAddOns.d.ts
@@ -1,19 +1,18 @@
 import DataExtractor from './DataExtractor.js';
 import { ROSSerialAddOnStatus } from './RICROSSerial.js';
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE = "00000083";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT = "00000084";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR = "00000085";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1 = "00000086";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT = "00000087";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM = "00000088";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE = "00000089";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_NOISE = "0000008A";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO = "0000008B";
-export declare const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2 = "0000008C";
-export declare function getHWElemTypeStr(whoAmITypeCode: string | undefined, whoAmI: string | undefined): string;
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE = "VCNL4200";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT = "lightsensor";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR = "coloursensor";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT = "IRFoot";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT = "LEDfoot";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM = "LEDarm";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE = "LEDeye";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_NOISE = "noisesensor";
+export declare const RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO = "roboservo3";
+export declare function getHWElemTypeStr(whoAmI: string | undefined): string;
 export declare class RICAddOnBase {
     _name: string;
-    _deviceTypeID: number;
+    _whoAmI: string;
     constructor(name: string);
     processPublishedData(addOnID: number, statusByte: number, rawData: Uint8Array): ROSSerialAddOnStatus;
 }
@@ -35,7 +34,7 @@ export declare class RICAddOnLEDEye extends RICAddOnBase {
 }
 export declare class RICAddOnIRFoot extends RICAddOnBase {
     _dataExtractor: DataExtractor;
-    constructor(name: string, deviceTypeID: number);
+    constructor(name: string);
     processPublishedData(addOnID: number, statusByte: number, rawData: Uint8Array): ROSSerialAddOnStatus;
 }
 export declare class RICAddOnColourSensor extends RICAddOnBase {

--- a/dist/RICAddOns.js
+++ b/dist/RICAddOns.js
@@ -2,16 +2,26 @@ import DataExtractor, { DataExtractorVarType } from './DataExtractor.js';
 import { ROSSerialAddOnStatus } from './RICROSSerial.js';
 import RICUtils from './RICUtils.js';
 // RIC ADDON CODES
-export const RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE = '00000083'; //131
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT = '00000084'; //132
-export const RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR = '00000085'; //133
-export const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1 = '00000086'; //134
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT = '00000087'; //135
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM = '00000088'; //136
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE = '00000089'; //137
-export const RIC_WHOAMI_TYPE_CODE_ADDON_NOISE = '0000008A'; //138
-export const RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO = '0000008B'; //139
-export const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2 = '0000008C'; //140
+export const RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE = "VCNL4200";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT = "lightsensor";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR = "coloursensor";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT = "IRFoot";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT = "LEDfoot";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM = "LEDarm";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE = "LEDeye";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_NOISE = "noisesensor";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO = "roboservo3";
+const whoAmIToTypeStrMAP = {
+    [RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO]: 'GripperArm',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT]: 'DiscoFoot',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM]: 'DiscoArm',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE]: 'DiscoEyes',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT]: 'IRFoot',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR]: 'ColourSensor',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE]: 'DistanceSensor',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_NOISE]: 'NoiseSensor',
+    [RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT]: 'LightSensor'
+};
 // Format definitions
 const ADDON_IRFOOT_FORMAT_DEF = {
     fields: [
@@ -162,39 +172,19 @@ const ADDON_NOISESENSOR_FORMAT_DEF = {
         },
     ],
 };
-export function getHWElemTypeStr(whoAmITypeCode, whoAmI) {
-    RICUtils.debug(`getting type code for ${whoAmITypeCode}`);
-    if (whoAmITypeCode === undefined) {
+export function getHWElemTypeStr(whoAmI) {
+    RICUtils.debug(`getting type code for ${whoAmI}`);
+    console.log(whoAmI, 'RICAddOns.ts', 'line: ', '186');
+    if (whoAmI === undefined) {
         return `Undefined whoamiTypeCode`;
     }
-    switch (parseInt(whoAmITypeCode)) {
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO):
-            return 'GripperArm';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT):
-            return 'DiscoFoot';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM):
-            return 'DiscoArm';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE):
-            return 'DiscoEyes';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1):
-            return 'IRFoot';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2):
-            return 'IRFoot';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR):
-            return 'ColourSensor';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE):
-            return 'DistanceSensor';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_NOISE):
-            return 'NoiseSensor';
-        case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT):
-            return 'LightSensor';
-    }
-    return `Unknown (${whoAmI} - ${whoAmITypeCode})`;
+    console.log(whoAmIToTypeStrMAP[whoAmI], 'RICAddOns.ts', 'line: ', '191');
+    return whoAmIToTypeStrMAP[whoAmI] ? whoAmIToTypeStrMAP[whoAmI] : `Unknown (${whoAmI})`;
 }
 export class RICAddOnBase {
     constructor(name) {
         this._name = '';
-        this._deviceTypeID = 0;
+        this._whoAmI = '';
         this._name = name;
     }
     processPublishedData(addOnID, statusByte, rawData) {
@@ -205,14 +195,14 @@ export class RICAddOnBase {
 export class RICAddOnGripServo extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO;
     }
     processPublishedData(addOnID, statusByte) {
         // Status to return
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         return retStatus;
@@ -221,7 +211,7 @@ export class RICAddOnGripServo extends RICAddOnBase {
 export class RICAddOnLEDFoot extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT;
     }
     processPublishedData(addOnID, statusByte) {
         // Status to return
@@ -229,7 +219,7 @@ export class RICAddOnLEDFoot extends RICAddOnBase {
         // console.log("RICADDONMANAGER: debugging info");
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         return retStatus;
@@ -238,14 +228,14 @@ export class RICAddOnLEDFoot extends RICAddOnBase {
 export class RICAddOnLEDArm extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM;
     }
     processPublishedData(addOnID, statusByte) {
         // Status to return
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         return retStatus;
@@ -254,23 +244,23 @@ export class RICAddOnLEDArm extends RICAddOnBase {
 export class RICAddOnLEDEye extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE;
     }
     processPublishedData(addOnID, statusByte) {
         // Status to return
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         return retStatus;
     }
 }
 export class RICAddOnIRFoot extends RICAddOnBase {
-    constructor(name, deviceTypeID) {
+    constructor(name) {
         super(name);
-        this._deviceTypeID = deviceTypeID;
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT;
         this._dataExtractor = new DataExtractor(name, ADDON_IRFOOT_FORMAT_DEF);
     }
     processPublishedData(addOnID, statusByte, rawData) {
@@ -278,7 +268,7 @@ export class RICAddOnIRFoot extends RICAddOnBase {
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -288,7 +278,7 @@ export class RICAddOnIRFoot extends RICAddOnBase {
 export class RICAddOnColourSensor extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR;
         this._dataExtractor = new DataExtractor(name, ADDON_COLOURSENSOR_FORMAT_DEF);
     }
     processPublishedData(addOnID, statusByte, rawData) {
@@ -296,7 +286,7 @@ export class RICAddOnColourSensor extends RICAddOnBase {
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -306,7 +296,7 @@ export class RICAddOnColourSensor extends RICAddOnBase {
 export class RICAddOnDistanceSensor extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE;
         this._dataExtractor = new DataExtractor(name, ADDON_DISTANCESENSOR_FORMAT_DEF);
     }
     processPublishedData(addOnID, statusByte, rawData) {
@@ -314,7 +304,7 @@ export class RICAddOnDistanceSensor extends RICAddOnBase {
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -324,7 +314,7 @@ export class RICAddOnDistanceSensor extends RICAddOnBase {
 export class RICAddOnLightSensor extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT;
         this._dataExtractor = new DataExtractor(name, ADDON_LIGHTSENSOR_FORMAT_DEF);
     }
     processPublishedData(addOnID, statusByte, rawData) {
@@ -332,7 +322,7 @@ export class RICAddOnLightSensor extends RICAddOnBase {
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -342,7 +332,7 @@ export class RICAddOnLightSensor extends RICAddOnBase {
 export class RICAddOnNoiseSensor extends RICAddOnBase {
     constructor(name) {
         super(name);
-        this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_NOISE);
+        this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_NOISE;
         this._dataExtractor = new DataExtractor(name, ADDON_NOISESENSOR_FORMAT_DEF);
     }
     processPublishedData(addOnID, statusByte, rawData) {
@@ -350,7 +340,7 @@ export class RICAddOnNoiseSensor extends RICAddOnBase {
         const retStatus = new ROSSerialAddOnStatus();
         // Extract data
         retStatus.id = addOnID;
-        retStatus.deviceTypeID = this._deviceTypeID;
+        retStatus.whoAmI = this._whoAmI;
         retStatus.name = this._name;
         retStatus.status = statusByte;
         retStatus.vals = this._dataExtractor.extractData(rawData);

--- a/dist/RICConnMgrWS.js
+++ b/dist/RICConnMgrWS.js
@@ -133,7 +133,7 @@ export default class RICConnMgrWS {
             // Connect to websocket
             // try {
             //     this._webSocket = await this.webSocketOpen(wsURL);
-            // } catch (error) {
+            // } catch (error: any) {
             //     RICUtils.debug(`Unable to create WebSocket ${error.toString()}`);
             //     return false;
             // }

--- a/dist/RICROSSerial.d.ts
+++ b/dist/RICROSSerial.d.ts
@@ -30,7 +30,7 @@ export declare class ROSSerialPowerStatus {
 }
 export declare class ROSSerialAddOnStatus {
     id: number;
-    deviceTypeID: number;
+    whoAmI: string;
     name: string;
     status: number;
     vals: {};

--- a/dist/RICROSSerial.js
+++ b/dist/RICROSSerial.js
@@ -36,7 +36,7 @@ export class ROSSerialPowerStatus {
 export class ROSSerialAddOnStatus {
     constructor() {
         this.id = 0;
-        this.deviceTypeID = 0;
+        this.whoAmI = '';
         this.name = '';
         this.status = 0;
         this.vals = {};

--- a/src/Marty.ts
+++ b/src/Marty.ts
@@ -76,6 +76,7 @@ export class Marty {
 
     // HWElems (connected to RIC)
     _hwElems: Array<RICHWElem> = new Array<RICHWElem>();
+    _hwElems2: Array<RICHWElem> = new Array<RICHWElem>();
 
     // Add-on Manager
     _addOnManager = new RICAddOnManager();
@@ -155,6 +156,7 @@ export class Marty {
         this._ricMsgHandler.registerForResults(this);
         this._ricMsgHandler.registerMsgSender(this._connManager);
         this._ricFileHandler.registerMsgSender(this._connManager);
+        console.log("initialising marty", 'Marty.ts', 'line: ', '158');
     }
 
     // Callback for RIC events including data
@@ -212,35 +214,35 @@ export class Marty {
             RICUtils.debug(
                 `eventConnect - RIC Version ${this._systemInfo.SystemVersion}`,
             );
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('eventConnect - failed to get version ' + error);
         }
 
         // Get RIC name
         try {
             await this.getRICName();
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('eventConnect - failed to get RIC name ' + error);
         }
 
         // Get calibration info
         try {
             this._calibInfo = await this.getRICCalibInfo();
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('eventConnect - failed to get calib info ' + error);
         }
 
         // Get HWElems (connected to RIC)
         try {
             await this.getHWElemList();
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('eventConnect - failed to get HWElems ' + error);
         }
 
         // Subscribe for updates
         try {
             await this.subscribeForUpdates(true);
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn(`eventConnect - subscribe for updates failed ${error.toString()}`)
         }
 
@@ -283,7 +285,7 @@ export class Marty {
                 'robot/' + arg,
                 true,
             );
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('robotControl failed ' + error.toString());
             return new RICOKFail();
         }
@@ -304,7 +306,7 @@ export class Marty {
                 'pwrctrl/' + arg,
                 true,
             );
-        } catch (error) {
+        } catch (error: any) {
            RICUtils.warn('powerControl failed ' + error.toString());
             return new RICOKFail();
         }
@@ -326,7 +328,7 @@ export class Marty {
                 'filerun/' + fileName,
                 true,
             );
-        } catch (error) {
+        } catch (error: any) {
            RICUtils.warn('fileRun failed ' + error.toString());
             return new RICOKFail();
         }
@@ -353,7 +355,7 @@ export class Marty {
             this._ricFriendlyNameIsSet = true;
             this._reportConnEvent(RICEvent.SET_RIC_NAME_SUCCESS, { newName: nameThatHasBeenSet });
             return nameThatHasBeenSet;
-        } catch (error) {
+        } catch (error: any) {
             this._reportConnEvent(RICEvent.SET_RIC_NAME_FAILED);
             return '';
         }
@@ -375,7 +377,7 @@ export class Marty {
                 this._ricFriendlyNameIsSet = msgRsltJsonObj.friendlyNameIsSet != 0;
             }
             return msgRsltJsonObj;
-        } catch (error) {
+        } catch (error: any) {
             return new RICNameResponse();
         }
     }
@@ -395,7 +397,7 @@ export class Marty {
             >('v', true);
            RICUtils.debug(`getRICSystemInfo returned ${JSON.stringify(ricSystemInfo)}`);
             return ricSystemInfo;
-        } catch (error) {
+        } catch (error: any) {
            RICUtils.warn(`getRICSystemInfo Failed to get version ${error.toString()}`);
             return new RICSystemInfo();
         }
@@ -416,7 +418,7 @@ export class Marty {
             >('calibrate', true);
            RICUtils.debug(`getRICCalibInfo returned ${JSON.stringify(ricCalibInfo)}`);
             return ricCalibInfo;
-        } catch (error) {
+        } catch (error: any) {
            RICUtils.warn(`getRICCalibInfo Failed to get version ${error.toString()}`);
             return new RICCalibInfo();
         }
@@ -450,7 +452,7 @@ export class Marty {
                 RICOKFail
             >(enable ? subscribeEnable : subscribeDisable, true);
            RICUtils.debug(`subscribe enable/disable returned ${JSON.stringify(ricResp)}`);
-        } catch (error) {
+        } catch (error: any) {
            RICUtils.warn(`getRICCalibInfo Failed to get version ${error.toString()}`);
         }
     }
@@ -478,7 +480,7 @@ export class Marty {
             let cmdUrl = 'traj/' + trajName;
             if (paramQueryStr.length > 0) cmdUrl += '?' + paramQueryStr;
             return await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(cmdUrl, true);
-        } catch (error) {
+        } catch (error: any) {
            RICUtils.warn('runTrajectory failed' + error.toString());
             return new RICOKFail();
         }
@@ -505,25 +507,25 @@ export class Marty {
                 if (msgContent.command === 'listFiles') {
                     try {
                         // TODO
-                    } catch (error) {
+                    } catch (error: any) {
                         return new RICOKFail();
                     }
                 } else if (msgContent.command === 'saveFile') {
                     try {
                         // TODO
-                    } catch (error) {
+                    } catch (error: any) {
                         return new RICOKFail();
                     }
                 } else if (msgContent.command === 'deleteFile') {
                     try {
                         // TODO
-                    } catch (error) {
+                    } catch (error: any) {
                         return new RICOKFail();
                     }
                 } else if (msgContent.command === 'loadFile') {
                     try {
                         // TODO
-                    } catch (error) {
+                    } catch (error: any) {
                         return new RICOKFail();
                     }
                 } else if (msgContent.command === 'playRawSound')
@@ -542,7 +544,7 @@ export class Marty {
                     }
                     return new RICOKFail();
                 }
-            } catch (error) {
+            } catch (error: any) {
                 RICUtils.warn('runCommand failed to parse JSON ' + error.toString());
                     return new RICOKFail();
             }    
@@ -561,7 +563,7 @@ export class Marty {
                     restCmdOrJsonCmd,
                     true,
                 );
-            } catch (error) {
+            } catch (error: any) {
             RICUtils.warn('runCommand failed' + error.toString());
                 return new RICOKFail();
             }
@@ -583,7 +585,7 @@ export class Marty {
                 'hwfwupd',
                 true,
             );
-        } catch (error) {
+        } catch (error: any) {
            RICUtils.warn('hwElemFirmwareUpdate get status failed' + error.toString());
             return new RICOKFail();
         }
@@ -591,8 +593,8 @@ export class Marty {
 
 
     //get the name of the addons type from the type code
-    convertHWElemType(whoAmITypeCode: string | undefined, whoAmI: string | undefined){
-        return this._addOnManager.convertHWElemType(whoAmITypeCode, whoAmI);
+    convertHWElemType(whoAmI: string | undefined){
+        return this._addOnManager.convertHWElemType(whoAmI);
     }
 
 
@@ -617,7 +619,7 @@ export class Marty {
             this._hwElems = ricHWList.hw;
             this._addOnManager.setHWElems(this._hwElems);
             return ricHWList;
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('getHWElemList Failed to get list of HWElems' + error.toString());
             return new RICHWElemList();
         }
@@ -641,7 +643,7 @@ export class Marty {
                 true,
             );
             return msgRslt;
-        } catch (error) {
+        } catch (error: any) {
             return new RICOKFail();
         }
     }
@@ -662,7 +664,7 @@ export class Marty {
             );
             RICUtils.debug('getAddOnList returned ' + addOnList);
             return addOnList;
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('getAddOnList Failed to get list of add-ons' + error.toString());
             return new RICAddOnList();
         }
@@ -684,7 +686,7 @@ export class Marty {
             );
             RICUtils.debug('getFileList returned ' + ricFileList);
             return ricFileList;
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('getFileList Failed to get file list' + error.toString());
             return new RICFileList();
         }
@@ -754,7 +756,7 @@ export class Marty {
                         true,
                     );
                     if (rslt.rslt != 'ok') overallResult = false;
-                } catch (error) {
+                } catch (error: any) {
                     RICUtils.warn(`calibrate failed on joint ${jnt}` + error.toString());
                 }
 
@@ -773,7 +775,7 @@ export class Marty {
                         true,
                     );
                     if (rslt.rslt != 'ok') overallResult = false;
-                } catch (error) {
+                } catch (error: any) {
                     RICUtils.warn(`enable failed on joint ${jnt}` + error.toString());
                 }
             }
@@ -818,7 +820,7 @@ export class Marty {
                 'https://updates.robotical.io/marty2/current_version.json',
             );
             this._lastestVersionInfo = response.data;
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('checkForUpdate failed to get latest from internet');
             this._reportConnEvent(RICEvent.UPDATE_CANT_REACH_SERVER);
         }
@@ -835,7 +837,7 @@ export class Marty {
             RICUtils.debug(
                 `checkForUpdate RIC Version ${this._systemInfo.SystemVersion}`,
             );
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('checkForUpdate - failed to get version ' + error);
             return false;
         }
@@ -858,7 +860,7 @@ export class Marty {
                 this._reportConnEvent(RICEvent.UPDATE_NOT_AVAILABLE);
                 return false;
             }
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn('Failed to get latest version from internet');
             this._reportConnEvent(RICEvent.UPDATE_CANT_REACH_SERVER);
             return false;
@@ -909,7 +911,7 @@ export class Marty {
                 if (this.TEST_PRETEND_ELEM_UPDATE_REQD) {
                     this._updateElemsRequired = true;
                 }
-            } catch (error) {
+            } catch (error: any) {
                 RICUtils.warn(
                     'isUpdateRequired failed to get hw-elem firmware update status',
                 );
@@ -1002,7 +1004,7 @@ export class Marty {
                     throw Error('file download res null');
                 }
             }
-        } catch (error) {
+        } catch (error: any) {
             RICUtils.warn(error);
             this._reportConnEvent(RICEvent.UPDATE_FAILED + error.toString());
             return;
@@ -1062,8 +1064,8 @@ export class Marty {
                 );
                 sentBytes += firmwareData[fwIdx].length;
             }
-        } catch (error) {
-            RICUtils.warn(error);
+        } catch (error: any) {
+            RICUtils.warn(error as string);
             this._reportConnEvent(RICEvent.UPDATE_FAILED);
             return;
         }
@@ -1118,7 +1120,7 @@ export class Marty {
                         firmwareUpdateConfirmed = true;
                     }
                     break;
-                } catch (error) {
+                } catch (error: any) {
                     RICUtils.warn(
                         'fwUpdate - failed to get version attempt ' +
                         fwUpdateCheckCount.toString() + 'error' + error.toString()
@@ -1157,7 +1159,7 @@ export class Marty {
             const updateCmd = `hwfwupd/${elemFw.elemType}/${elemFw.destname}/all`;
             try {
                 await this._ricMsgHandler.sendRICRESTURL<RICOKFail>(updateCmd, true);
-            } catch (error) {
+            } catch (error: any) {
                 RICUtils.warn('failed to start hw-elem firmware update cmd ' + updateCmd);
 
                 // Continue with other firmwares
@@ -1195,7 +1197,7 @@ export class Marty {
                         allElemsUpdatedOk = elUpdRslt.st.i === 0;
                         break;
                     }
-                } catch (error) {
+                } catch (error: any) {
                     RICUtils.warn('failed to get hw-elem firmware update status');
                 }
             }

--- a/src/RICAddOnManager.ts
+++ b/src/RICAddOnManager.ts
@@ -10,8 +10,7 @@ import {
   RICAddOnLEDArm,
   RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE,
   RICAddOnLEDEye,
-  RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1,
-  RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2,
+  RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT,
   RICAddOnIRFoot,
   RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR,
   RICAddOnColourSensor,
@@ -38,8 +37,8 @@ export default class RICAddOnManager {
   }
 
 
-  convertHWElemType(whoAmITypeCode: string | undefined, whoAmI: string | undefined){
-    return getHWElemTypeStr(whoAmITypeCode, whoAmI);
+  convertHWElemType(whoAmI: string | undefined){
+    return getHWElemTypeStr(whoAmI);
   } 
 
 
@@ -47,52 +46,50 @@ export default class RICAddOnManager {
     const addOnMap: Dictionary<RICAddOnBase> = {};
     // Iterate HWElems to find addons
     for (const hwElem of hwElems) {
-      const dtid = parseInt("0x" + hwElem.whoAmITypeCode);
+      console.log(hwElem.whoAmI, 'RICAddOnManager.ts', 'line: ', '50');
       if (hwElem.type === 'RSAddOn') {
-        switch (dtid) {
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO):
+        switch (hwElem.whoAmI) {
+          case RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnGripServo(
               hwElem.name
             );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnLEDFoot(
               hwElem.name
             );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnLEDArm(
               hwElem.name
             );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnLEDEye(
               hwElem.name
             );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1):
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnIRFoot(
               hwElem.name,
-              dtid
              );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnColourSensor(
               hwElem.name,
             );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnDistanceSensor(
               hwElem.name,
             );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnLightSensor(
               hwElem.name,
             );
             break;
-          case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_NOISE):
+          case RIC_WHOAMI_TYPE_CODE_ADDON_NOISE:
             addOnMap[hwElem.IDNo.toString()] = new RICAddOnNoiseSensor(
               hwElem.name,
             );

--- a/src/RICAddOns.ts
+++ b/src/RICAddOns.ts
@@ -2,17 +2,29 @@ import DataExtractor, { DataExtractorVarType } from './DataExtractor.js';
 import { ROSSerialAddOnStatus } from './RICROSSerial.js';
 import RICUtils from './RICUtils.js';
 
+
 // RIC ADDON CODES
-export const RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE  = '00000083'; //131
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT     = '00000084'; //132
-export const RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR    = '00000085'; //133
-export const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1 = '00000086'; //134
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT   = '00000087'; //135
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM    = '00000088'; //136
-export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE    = '00000089'; //137
-export const RIC_WHOAMI_TYPE_CODE_ADDON_NOISE     = '0000008A'; //138
-export const RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO = '0000008B'; //139
-export const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2 = '0000008C'; //140
+export const RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE = "VCNL4200";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT = "lightsensor";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR = "coloursensor";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT = "IRFoot";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT = "LEDfoot";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM = "LEDarm";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE = "LEDeye";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_NOISE = "noisesensor";
+export const RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO = "roboservo3";
+
+const whoAmIToTypeStrMAP: {[key: string]: string} = {
+   [RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO]:'GripperArm',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT]: 'DiscoFoot',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM]: 'DiscoArm',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE]: 'DiscoEyes',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT]: 'IRFoot',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR]: 'ColourSensor',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE]: 'DistanceSensor',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_NOISE]: 'NoiseSensor',
+  [RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT]: 'LightSensor'
+};
 
 // Format definitions
 const ADDON_IRFOOT_FORMAT_DEF = {
@@ -169,49 +181,17 @@ const ADDON_NOISESENSOR_FORMAT_DEF = {
   ],
 };
 
-export function getHWElemTypeStr(whoAmITypeCode: string | undefined, whoAmI: string | undefined) {
-  RICUtils.debug(`getting type code for ${whoAmITypeCode}`);
-  if (whoAmITypeCode === undefined) {
+export function getHWElemTypeStr(whoAmI: string | undefined) {
+  RICUtils.debug(`getting type code for ${whoAmI}`);
+  if (whoAmI === undefined) {
     return `Undefined whoamiTypeCode`;
   }
-  switch (parseInt(whoAmITypeCode)) {
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO):
-      return 'GripperArm';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT):
-      return 'DiscoFoot';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM):
-      return 'DiscoArm';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE):
-      return 'DiscoEyes';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V1):
-      return 'IRFoot';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT_V2):
-      return 'IRFoot';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR):
-      return 'ColourSensor';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE):
-      return 'DistanceSensor';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_NOISE):
-      return 'NoiseSensor';
-
-    case parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT):
-      return 'LightSensor';
-  }
-  return `Unknown (${whoAmI} - ${whoAmITypeCode})`;
+  return whoAmIToTypeStrMAP[whoAmI] ? whoAmIToTypeStrMAP[whoAmI] : `Unknown (${whoAmI})`;
 }
 
 export class RICAddOnBase {
   _name = '';
-  _deviceTypeID = 0;
+  _whoAmI = '';
   constructor(name: string) {
     this._name = name;
   }
@@ -231,7 +211,7 @@ export class RICAddOnBase {
 export class RICAddOnGripServo extends RICAddOnBase {
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_GRIPSERVO;
   }
   
   processPublishedData(
@@ -243,7 +223,7 @@ export class RICAddOnGripServo extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     return retStatus;
@@ -253,7 +233,7 @@ export class RICAddOnGripServo extends RICAddOnBase {
 export class RICAddOnLEDFoot extends RICAddOnBase {
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LEDFOOT;
   }
   processPublishedData(
     addOnID: number,
@@ -266,7 +246,7 @@ export class RICAddOnLEDFoot extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     return retStatus;
@@ -276,7 +256,7 @@ export class RICAddOnLEDFoot extends RICAddOnBase {
 export class RICAddOnLEDArm extends RICAddOnBase {
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LEDARM;
   }
   processPublishedData(
     addOnID: number,
@@ -287,7 +267,7 @@ export class RICAddOnLEDArm extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     return retStatus;
@@ -297,7 +277,7 @@ export class RICAddOnLEDArm extends RICAddOnBase {
 export class RICAddOnLEDEye extends RICAddOnBase {
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LEDEYE;
   }
   processPublishedData(
     addOnID: number,
@@ -308,7 +288,7 @@ export class RICAddOnLEDEye extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     return retStatus;
@@ -319,9 +299,9 @@ export class RICAddOnLEDEye extends RICAddOnBase {
 
 export class RICAddOnIRFoot extends RICAddOnBase {
   _dataExtractor: DataExtractor;
-  constructor(name: string, deviceTypeID: number) {
+  constructor(name: string) {
     super(name);
-    this._deviceTypeID = deviceTypeID;
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_IRFOOT;
     this._dataExtractor = new DataExtractor(name, ADDON_IRFOOT_FORMAT_DEF);
   }
   processPublishedData(
@@ -334,7 +314,7 @@ export class RICAddOnIRFoot extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -346,7 +326,7 @@ export class RICAddOnColourSensor extends RICAddOnBase {
   _dataExtractor: DataExtractor;
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_COLOUR;
     this._dataExtractor = new DataExtractor(
       name,
       ADDON_COLOURSENSOR_FORMAT_DEF,
@@ -362,7 +342,7 @@ export class RICAddOnColourSensor extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -374,7 +354,7 @@ export class RICAddOnDistanceSensor extends RICAddOnBase {
   _dataExtractor: DataExtractor;
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_DISTANCE;
     this._dataExtractor = new DataExtractor(
       name,
       ADDON_DISTANCESENSOR_FORMAT_DEF,
@@ -390,7 +370,7 @@ export class RICAddOnDistanceSensor extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -402,7 +382,7 @@ export class RICAddOnLightSensor extends RICAddOnBase {
   _dataExtractor: DataExtractor;
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_LIGHT;
     this._dataExtractor = new DataExtractor(
       name,
       ADDON_LIGHTSENSOR_FORMAT_DEF,
@@ -418,7 +398,7 @@ export class RICAddOnLightSensor extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     retStatus.vals = this._dataExtractor.extractData(rawData);
@@ -430,7 +410,7 @@ export class RICAddOnNoiseSensor extends RICAddOnBase {
   _dataExtractor: DataExtractor;
   constructor(name: string) {
     super(name);
-    this._deviceTypeID = parseInt("0x" + RIC_WHOAMI_TYPE_CODE_ADDON_NOISE);
+    this._whoAmI = RIC_WHOAMI_TYPE_CODE_ADDON_NOISE;
     this._dataExtractor = new DataExtractor(
       name,
       ADDON_NOISESENSOR_FORMAT_DEF,
@@ -446,7 +426,7 @@ export class RICAddOnNoiseSensor extends RICAddOnBase {
 
     // Extract data
     retStatus.id = addOnID;
-    retStatus.deviceTypeID = this._deviceTypeID;
+    retStatus.whoAmI = this._whoAmI;
     retStatus.name = this._name;
     retStatus.status = statusByte;
     retStatus.vals = this._dataExtractor.extractData(rawData);

--- a/src/RICConnMgrWS.ts
+++ b/src/RICConnMgrWS.ts
@@ -145,7 +145,7 @@ export default class RICConnMgrWS {
         // Connect to websocket
         // try {
         //     this._webSocket = await this.webSocketOpen(wsURL);
-        // } catch (error) {
+        // } catch (error: any) {
         //     RICUtils.debug(`Unable to create WebSocket ${error.toString()}`);
         //     return false;
         // }
@@ -212,7 +212,7 @@ export default class RICConnMgrWS {
                     RICUtils.warn(`Websocket error: ${evt.message}`);
                     reject(evt);
                 }
-            } catch (error) {
+            } catch (error: any) {
                 RICUtils.warn('Websocket open failed: ' + error.toString());
                 reject(error);
             }

--- a/src/RICFileHandler.ts
+++ b/src/RICFileHandler.ts
@@ -388,7 +388,7 @@ export default class RICFileHandler {
         if (promRslt !== null)
           this._msgAwaitList.push(new FileBlockTrackInfo(promRslt));
       }
-    } catch (error) {
+    } catch (error: any) {
       RICUtils.warn(`_sendFileBlock error${error.toString()}`);
     }
     return blockLen;
@@ -407,7 +407,7 @@ export default class RICFileHandler {
       for (const promRslt of this._msgAwaitList) {
         try {
           await promRslt.get();
-        } catch (error) {
+        } catch (error: any) {
           RICUtils.warn(`awaitAll file part send failed ${error.toString()}`);
         }
       }
@@ -421,7 +421,7 @@ export default class RICFileHandler {
         const fileBlockTrackInfo = this._msgAwaitList.shift();
         try {
           await fileBlockTrackInfo!.get();
-        } catch (error) {
+        } catch (error: any) {
           RICUtils.warn(`awaitSome file part send failed ${error.toString()}`);
         }
       }

--- a/src/RICMsgHandler.ts
+++ b/src/RICMsgHandler.ts
@@ -369,7 +369,7 @@ export default class RICMsgHandler {
         if (!isNumbered) {
           (resolve as any)()
         }
-      } catch (error) {
+      } catch (error: any) {
         reject(error);
       }
     });
@@ -505,7 +505,7 @@ export default class RICMsgHandler {
                 this._msgTrackInfos[i].msgFrame!,
                 this._msgTrackInfos[i].withResponse,
               );
-            } catch (error) {
+            } catch (error: any) {
               RICUtils.warn('Retry message failed' + error.toString());
             }
           }

--- a/src/RICROSSerial.ts
+++ b/src/RICROSSerial.ts
@@ -55,7 +55,7 @@ export class ROSSerialPowerStatus {
 
 export class ROSSerialAddOnStatus {
   id = 0;
-  deviceTypeID = 0;
+  whoAmI = '';
   name = '';
   status = 0;
   vals = {};


### PR DESCRIPTION
Issue: device type id's are unique between different version of addons. That generates duplicated code and sloppy logic.

Solution: Refactor logic and use the whoAmI addons' value instead of tdid's.

Note: Changes in multiple repos:
[scratch-gui (wifi)](https://github.com/robotical/scratch3-gui/pull/52)
[scratch-vm (wifi)](https://github.com/robotical/scratch3-vm/pull/34)
[scratch-vm (phone app)](https://github.com/robotical/scratch3-vm/pull/35)
[marty-react-native](https://github.com/robotical/marty-react-native/pull/143)

[Jira ticket](https://robotical.atlassian.net/browse/BUGS-329)